### PR TITLE
Fix website 404 error for future messages

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,4 +4,15 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  // Add a proxy so that calls like `/api/letters` are forwarded to your backend when running the Vite dev server.
+  // The backend URL can be customized via the VITE_API_URL env var; otherwise it falls back to localhost:3000.
+  server: {
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_URL || 'http://localhost:3000',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 })


### PR DESCRIPTION
Add Vite proxy configuration to forward API calls to the backend, resolving 404 errors during local development.

During local development with the Vite dev server, API requests (e.g., `/api/letters`) were being handled by Vite itself, leading to 404 errors as Vite had no routes for them. This change configures Vite to proxy these requests to the backend server (defaulting to `http://localhost:3000` or `VITE_API_URL`).

---

[Open in Web](https://cursor.com/agents?id=bc-1ee4c211-7ea6-4aa6-8d6e-ea0887bc6d38) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1ee4c211-7ea6-4aa6-8d6e-ea0887bc6d38)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)