### PR TITLE
Handle 404 request failure

### DIFF
--- a/client/src/api/axios.ts
+++ b/client/src/api/axios.ts
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
 const api = axios.create({
-  // baseURL: '/api', // Optional: use relative paths
+  // Use the backend URL from environment variable if provided, otherwise fall back to relative "/api" path
+  baseURL: import.meta.env.VITE_API_URL || '/api',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/client/src/pages/PublicLettersPage.tsx
+++ b/client/src/pages/PublicLettersPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import axios from 'axios';
+import api from '../api/axios';
 import { useAuth } from '../contexts/AuthContext';
 
 interface Letter {
@@ -22,7 +22,7 @@ export default function PublicLettersPage() {
     const fetchPublicLetters = async () => {
       try {
         setLoading(true);
-        const response = await axios.get('/api/letters/public', {
+        const response = await api.get('/letters/public', {
           headers: {
             'Authorization': `Bearer ${token}`
           }

--- a/client/src/pages/WriteLetterPage.tsx
+++ b/client/src/pages/WriteLetterPage.tsx
@@ -2,7 +2,7 @@ import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import { useAuth } from '../contexts/AuthContext';
 import { useState } from 'react';
-import axios from 'axios';
+import api from '../api/axios';
 
 interface LetterFormData {
   subject: string;
@@ -64,7 +64,7 @@ export default function WriteLetterPage() {
       }
 
       try {
-        await axios.post('/api/letters', values, {
+        await api.post('/letters', values, {
           headers: {
             'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json'

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,4 +4,13 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  // Proxy API requests in development to the backend server
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
Configure client to connect to the backend API to resolve 404 errors.

The original setup caused 404s because the client's API calls were not reaching the correct backend routes. This PR configures the Vite dev server to proxy `/api` requests to the separate backend server (running on port 3000) and updates the axios base URL to use an environment variable or default to `/api`, ensuring the client can properly communicate with the letter API.

---

[Open in Web](https://cursor.com/agents?id=bc-775d9e6a-60b6-4bd8-b52f-436c27826f67) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-775d9e6a-60b6-4bd8-b52f-436c27826f67)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)